### PR TITLE
Simple style commands

### DIFF
--- a/consts.py
+++ b/consts.py
@@ -1,3 +1,12 @@
 QUEUE_NAME = "message_processor_queue.fifo"
 REGION = "eu-central-1"
 MESSAGE_GROUP_ID = "kirc"
+COMMAND_PREFIX = "/"
+COLORS = ['red', 'blue', 'yellow', 'green', 'black', 'pink', 'purple', 'orange', 'white', 'cyan']
+SIZES = {
+    'tiny': '8px',
+    'small': '12px',
+    'medium': '20px',
+    'large': '32px',
+    'huge': '196px'
+}

--- a/sqs_client.py
+++ b/sqs_client.py
@@ -1,5 +1,5 @@
 import boto3
-from consts import REGION, QUEUE_NAME, MESSAGE_GROUP_ID
+from consts import REGION, QUEUE_NAME, MESSAGE_GROUP_ID, COMMAND_PREFIX, COLORS, SIZES
 from datetime import datetime, timezone
 import uuid
 import json
@@ -14,10 +14,22 @@ def send_queue_message(message: str):
 def main():
     print("Velkommen til verdens enkleste SQS-klient.")
     print("Klienten kan avsluttes når som helst ved å holde inne CTRL + C.")
+    style = {}
     while True:
         print()
         print("Skriv inn meldingen du ønsker å sende til køen. For at meldingen faktisk skal bli sendt må du trykke på enter-tasten.")
         user_input = input()
+        if user_input.startswith(COMMAND_PREFIX):
+            command = user_input[len(COMMAND_PREFIX):]
+            if command == 'clear':
+                style = {}
+            elif command in COLORS: # e.g. /red, /blue, /black
+                style['color'] = command
+            elif command in SIZES:
+                style['font-size'] = SIZES[command]
+            else:
+                print(f'Unknown command {command}')
+            continue
         id = str(uuid.uuid4())
         timestamp = datetime.now(timezone.utc).astimezone().isoformat()
         msg = {
@@ -25,6 +37,8 @@ def main():
             "id": id, 
             "timestamp": timestamp, 
             }
+        if len(style) > 0:
+            msg['style'] = ''.join([f'{key}: {value};' for key, value in style.items()])
         send_queue_message(json.dumps(msg))
         print("Melding sendt!")
         


### PR DESCRIPTION
Made support for simple style commands (e.g. `/red`, `/blue`, `/tiny` and `/clear`)